### PR TITLE
Update oktaDiscoveryUrl in auth_okta_service.dart

### DIFF
--- a/example/lib/services/auth_okta_service.dart
+++ b/example/lib/services/auth_okta_service.dart
@@ -12,7 +12,7 @@ class AuthOktaService {
   static const String oktaIssuerUrl =
       'https://$oktaDomain/oauth2/$oktaAuthorizer';
   static const String oktaDiscoveryUrl =
-      'https://$oktaDomain/.well-known/openid-configuration';
+      '$oktaIssuerUrl/.well-known/openid-configuration';
 
   static const String oktaRedirectUrl =
       'com.bluestork.flutteroktaauth:/callback';


### PR DESCRIPTION
AuthOktaService oktaDiscoveryUrl is not forming correctly, However it's working and getting token and but the server is denying by saying the token is not a valid one. I figure out iOS / Android OKTA SDK using different approaches. 